### PR TITLE
Add asset_path() helper for linking to JS and CSS output bundles.

### DIFF
--- a/lib/bridgetown-slim/slim_templates.rb
+++ b/lib/bridgetown-slim/slim_templates.rb
@@ -11,9 +11,25 @@ module Bridgetown
       partial_segments.last.sub!(%r!^!, "_")
       partial_name = partial_segments.join("/")
 
-      Slim::Template.new(
-        site.in_source_dir(site.config[:partials_dir], "#{partial_name}.slim")
-      ).render(self, options)
+      search_directories = [site.config[:partials_dir], site.config[:components_dir]]
+      partial_file = nil
+
+      if partial_name.start_with?(*search_directories)
+        partial_file = site.in_source_dir("#{partial_name}.slim")
+      else
+        for directory in search_directories
+          partial_file = site.in_source_dir(directory, "#{partial_name}.slim")
+          if File.exists?(partial_file)
+            break 
+          else
+            partial_file = nil
+          end
+        end
+      end
+
+      partial_file = site.in_source_dir("#{partial_name}.slim") if partial_file == nil
+
+      Slim::Template.new(partial_file).render(self, options)
     end
 
     def asset_path(asset_type)

--- a/lib/bridgetown-slim/slim_templates.rb
+++ b/lib/bridgetown-slim/slim_templates.rb
@@ -15,6 +15,10 @@ module Bridgetown
         site.in_source_dir(site.config[:partials_dir], "#{partial_name}.slim")
       ).render(self, options)
     end
+
+    def asset_path(asset_type)
+      Bridgetown::Utils.parse_frontend_manifest_file(site, asset_type.to_s)
+    end
   end
 
   module Converters


### PR DESCRIPTION
Following the Bridgetown Documentation for how to link to [Output Bundles](https://www.bridgetownrb.com/docs/frontend-assets#linking-to-the-output-bundles), I noticed that the `asset_path` helper is currently missing when using slim templates.

This PR adds this `asset_path` helper to the `Bridgetown::SlimView` class.

It might also make sense to define `css` and `js` variables directly on `Bridgetown::SlimView` so that `css` and `js` can be passed like suggested in the documentation listed above, but I'm fine to just pass in symbols or strings for the `asset_type` (such as `:css`, `:js`). It should probably be mentioned in bridgetown-slim's documentation how this differs, though.