### PR TITLE
Add support for _components directory to SlimView#partial()

### DIFF
--- a/lib/bridgetown-slim/slim_templates.rb
+++ b/lib/bridgetown-slim/slim_templates.rb
@@ -11,9 +11,25 @@ module Bridgetown
       partial_segments.last.sub!(%r!^!, "_")
       partial_name = partial_segments.join("/")
 
-      Slim::Template.new(
-        site.in_source_dir(site.config[:partials_dir], "#{partial_name}.slim")
-      ).render(self, options)
+      search_directories = [site.config[:partials_dir], site.config[:components_dir]]
+      partial_file = nil
+
+      if partial_name.start_with?(*search_directories)
+        partial_file = site.in_source_dir("#{partial_name}.slim")
+      else
+        for directory in search_directories
+          partial_file = site.in_source_dir(directory, "#{partial_name}.slim")
+          if File.exists?(partial_file)
+            break
+          else
+            partial_file = nil
+          end
+        end
+      end
+
+      partial_file = site.in_source_dir("#{partial_name}.slim") if partial_file == nil
+
+      Slim::Template.new(partial_file).render(self, options)
     end
   end
 


### PR DESCRIPTION
This PR adds support for using the src/_components directory (through it's config option) as  it is often used throughout the Bridgetown Documentation. This PR directly applies to #2 

It also falls back to using any stated directory inside the source directory when trying to render out a partial that wasn't found in the _components or _partials directory. This can be nice if you want to create a custom directory structure for your project, allowing you to state specifically where your partial is located within the src directory.